### PR TITLE
Disallow attributes element with usergroup attribute

### DIFF
--- a/src/main/resources/findologic.xsd
+++ b/src/main/resources/findologic.xsd
@@ -121,7 +121,6 @@
                     <xs:sequence>
                         <xs:element type="keyValuesPair" name="attribute" maxOccurs="unbounded" minOccurs="0"/>
                     </xs:sequence>
-                    <xs:attribute type="usergroupHash" name="usergroup" use="optional"/>
                 </xs:complexType>
             </xs:element>
         </xs:sequence>


### PR DESCRIPTION
Item attributes currently do not support usergroups because there is no use
case at this time. The schema now reflects reality better.

Existing exported product data has been checked to ensure that this does not
break compatibility with existing exports.
